### PR TITLE
Remove bg color for PR navbar

### DIFF
--- a/github-pr-navbar.user.js
+++ b/github-pr-navbar.user.js
@@ -21,7 +21,7 @@ function addGlobalStyle(css) {
 addGlobalStyle(`
   #own-clonedtabs .tabnav-tab { padding: 5px 2px; max-width: 20px; height: 22px; white-space: nowrap;
                                 overflow: hidden; border: 0; border-radius: 0px !important; display: flex; }
-  #own-clonedtabs { margin: -5px 0 0 10px; background-color: rgba(255, 255, 255, 1.0); min-width: 80px; }
+  #own-clonedtabs { margin: -5px 0 0 10px; min-width: 80px; }
 `);
 
 function createClone() {


### PR DESCRIPTION
Leaving the background color as it is allows the extension to visually integrate into the existing design when using the dark theme of GH.